### PR TITLE
 add variable selection option to taxonomy barplot

### DIFF
--- a/inst/explore-anacapa-output/server.R
+++ b/inst/explore-anacapa-output/server.R
@@ -372,7 +372,7 @@ server <- function(input, output)({
       } else {
         physeqGlommed = tax_glom(data_subset(), input$taxon_level)
       }
-      plot_bar(physeqGlommed, fill = input$taxon_level) + theme_ranacapa() +
+      plot_bar(physeqGlommed, fill = input$taxon_level) + theme_ranacapa() + facet_grid = input$var +
         theme(axis.text.x = element_text(angle = 45)) +
         theme(axis.title = element_blank())
       gp <- ggplotly() %>%


### PR DESCRIPTION
Add a variable selection dropdown menu to taxonomy barplot in order to add facets and variables for the figure:
changes:
add facet_grid = input$var on L375

To check:
can add a similar feature to heatmap tab?
ui.R file: 
check lines 25-27 and 53-54 if fails